### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "autoprefixer": "^6.3.6",
-    "babel-core": "^5.8.34",
+    "babel-core": "^6.10.4",
     "body-parser": "^1.12.4",
     "chokidar": "^1.3.0",
     "class-extend": "^0.1.1",


### PR DESCRIPTION
post-web is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `babel-core`

This PR fixes the ReDoS vulnerability by upgrading `babel-core` to version 6.10.4.

Check out the [Snyk test report](https://snyk.io/test/github/qiu8310/post-web) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
